### PR TITLE
chore: move repo to loopbackio org

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,9 +2,6 @@
 Questions:
   https://groups.google.com/forum/#!forum/loopbackjs
   https://gitter.im/strongloop/loopback
-Immediate support:
-  https://strongloop.com/api-connect-faqs/
-  https://strongloop.com/node-js/subscription-plans/
 -->
 
 # Description/Steps to reproduce

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+### Contributing ###
+
+Thank you for your interest in `strong-error-handler`, an open source project
+as part of LoopBack.
+
+Contributing to `strong-error-handler` is easy. In a few simple steps:
+
+  * Ensure that your effort is aligned with the project's roadmap by
+    talking to the maintainers, especially if you are going to spend a
+    lot of time on it.
+
+  * Make something better or fix a bug.
+
+  * Adhere to code style outlined in the [Google C++ Style Guide][] and
+    [Google Javascript Style Guide][].
+
+  * Sign the [Developer Certificate of Origin](#developer-certificate-of-origin)
+
+  * Submit a pull request through Github.
+
+
+### Developer Certificate of Origin
+
+This project uses [DCO](https://developercertificate.org/). Be sure to sign off
+your commits using the `-s` flag or adding `Signed-off-By: Name<Email>` in the
+commit message.
+
+**Example**
+
+```
+git commit -s -m "feat: my commit message"
+```
+
+[Google C++ Style Guide]: https://google.github.io/styleguide/cppguide.html
+[Google Javascript Style Guide]: https://google.github.io/styleguide/javascriptguide.xml

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/strongloop/strong-error-handler.git"
+    "url": "https://github.com/loopbackio/strong-error-handler.git"
   },
   "main": "lib/handler.js",
   "scripts": {


### PR DESCRIPTION
As part of https://github.com/strongloop/loopback-next/issues/7595

Signed-off-by: Diana Lau <dhmlau@ca.ibm.com>

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
