### PR TITLE
Honour expose property of http-errors

### DIFF
--- a/lib/data-builder.js
+++ b/lib/data-builder.js
@@ -35,9 +35,9 @@ function buildResponseData(err, options) {
   }
 
   if (data.statusCode >= 400 && data.statusCode <= 499) {
-    fillBadRequestError(data, err);
+    fillClientError(data, err);
   } else {
-    fillInternalError(data, err);
+    fillServerError(data, err);
   }
 
   const safeFields = options.safeFields || [];
@@ -66,14 +66,14 @@ function fillDebugData(data, err) {
   cloneAllProperties(data, err);
 }
 
-function fillBadRequestError(data, err) {
+function fillClientError(data, err) {
   data.name = err.name;
   data.message = err.message;
   data.code = err.code;
   data.details = err.details;
 }
 
-function fillInternalError(data, err) {
+function fillServerError(data, err) {
   data.message = httpStatus[data.statusCode] || 'Unknown Error';
 }
 

--- a/lib/data-builder.js
+++ b/lib/data-builder.js
@@ -74,7 +74,12 @@ function fillClientError(data, err) {
 }
 
 function fillServerError(data, err) {
-  data.message = httpStatus[data.statusCode] || 'Unknown Error';
+  if (err.expose) {
+    data.name = httpStatus[data.statusCode] || 'Unknown Error';
+    data.message = err.message;
+  } else {
+    data.message = httpStatus[data.statusCode] || 'Unknown Error';
+  }
 }
 
 function fillSafeFields(data, err, safeFields) {

--- a/test/handler.test.js
+++ b/test/handler.test.js
@@ -393,6 +393,33 @@ describe('strong-error-handler', function() {
       });
     });
 
+    it('honours expose=true when status=5xx', function(done) {
+      // Mock an error reported by fs.readFile
+      const error = new ErrorWithProps({
+        name: 'Error',
+        message: 'ENOENT: no such file or directory, open "/etc/passwd"',
+        errno: -2,
+        code: 'ENOENT',
+        expose: true,
+        syscall: 'open',
+        path: '/etc/password',
+      });
+      givenErrorHandlerForError(error);
+
+      requestJson().end(function(err, res) {
+        if (err) return done(err);
+
+        expect(res.body).to.have.property('error');
+        expect(res.body.error).to.eql({
+          statusCode: 500,
+          name: 'Internal Server Error',
+          message: 'ENOENT: no such file or directory, open "/etc/passwd"',
+        });
+
+        done();
+      });
+    });
+
     it('handles array argument as 500 when debug=false', function(done) {
       const errors = [new Error('ERR1'), new Error('ERR2'), 'ERR STRING'];
       givenErrorHandlerForError(errors);
@@ -679,6 +706,29 @@ describe('strong-error-handler', function() {
         });
     });
 
+    it('honours expose=true when status=5xx', function(done) {
+      const error = new ErrorWithProps({
+        name: 'Error',
+        message: 'Server out of disk space',
+        details: 'some details',
+        extra: 'sensitive data',
+        expose: true,
+      });
+      givenErrorHandlerForError(error);
+
+      requestHTML()
+        .end(function(err, res) {
+          expect(res.statusCode).to.eql(500);
+          const body = res.error.text;
+          expect(body).to.not.match(/some details/);
+          expect(body).to.not.match(/sensitive data/);
+          // only have the following
+          expect(body).to.match(/<title>Internal Server Error<\/title>/);
+          expect(body).to.match(/500(.*?)Server out of disk space/);
+          done();
+        });
+    });
+
     function requestHTML(url) {
       return request.get(url || '/')
         .set('Accept', 'text/html')
@@ -750,6 +800,30 @@ describe('strong-error-handler', function() {
           // only have the following
           expect(body).to.match(/<statusCode>500<\/statusCode>/);
           expect(body).to.match(/<message>Internal Server Error<\/message>/);
+          done();
+        });
+    });
+
+    it('honours expose=true when status=5xx', function(done) {
+      const error = new ErrorWithProps({
+        name: 'Error',
+        message: 'Server out of disk space',
+        details: 'some details',
+        extra: 'sensitive data',
+        expose: true,
+      });
+      givenErrorHandlerForError(error);
+
+      requestXML()
+        .end(function(err, res) {
+          expect(res.statusCode).to.eql(500);
+          const body = res.error.text;
+          expect(body).to.not.match(/some details/);
+          expect(body).to.not.match(/sensitive data/);
+          // only have the following
+          expect(body).to.match(/<statusCode>500<\/statusCode>/);
+          expect(body).to.match(/<name>Internal Server Error<\/name>/);
+          expect(body).to.match(/<message>Server out of disk space<\/message>/);
           done();
         });
     });


### PR DESCRIPTION
### Description
This commit adds support for the `expose` property used by the
`http-errors` module, which allows developers to explicitly signal the
error message to be passed to the HTTP response for errors. This is
useful for certain errors (e.g., those with status code >=`500`) where the
original error message is otherwise suppressed by default.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to #78

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
