### PR TITLE
feat: honor "expose" property of http-errors

### DIFF
--- a/lib/data-builder.js
+++ b/lib/data-builder.js
@@ -35,9 +35,9 @@ function buildResponseData(err, options) {
   }
 
   if (data.statusCode >= 400 && data.statusCode <= 499) {
-    fillBadRequestError(data, err);
+    fillClientError(data, err);
   } else {
-    fillInternalError(data, err);
+    fillServerError(data, err);
   }
 
   const safeFields = options.safeFields || [];
@@ -66,15 +66,20 @@ function fillDebugData(data, err) {
   cloneAllProperties(data, err);
 }
 
-function fillBadRequestError(data, err) {
+function fillClientError(data, err) {
   data.name = err.name;
   data.message = err.message;
   data.code = err.code;
   data.details = err.details;
 }
 
-function fillInternalError(data, err) {
-  data.message = httpStatus[data.statusCode] || 'Unknown Error';
+function fillServerError(data, err) {
+  if (err.expose) {
+    data.name = httpStatus[data.statusCode] || 'Unknown Error';
+    data.message = err.message;
+  } else {
+    data.message = httpStatus[data.statusCode] || 'Unknown Error';
+  }
 }
 
 function fillSafeFields(data, err, safeFields) {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "main": "lib/handler.js",
   "scripts": {
     "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "test": "mocha",
     "posttest": "npm run lint"
   },


### PR DESCRIPTION
### Description
This is a rework for PR https://github.com/loopbackio/strong-error-handler/pull/138.

@getsnoopy, I was trying to rebase your branch to the latest code since PR #138 is relatively old, but I don't have the permission to push. I've added your sign off in my PR to preserve your authorship. 

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
