### PR TITLE
BREAKING CHANGE: drop Node.js 20 support

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,15 +19,14 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node-version:
-          - 16
-          - 18
-          - 20
-          - 21
+          - 22
+          - 24
+          - 26
         include:
           - os: macos-latest
-            node-version: 20 # LTS
+            node-version: 22 # LTS
           - os: windows-latest
-            node-version: 20 # LTS
+            node-version: 22 # LTS
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -74,7 +73,7 @@ jobs:
       - name: Use Node.js 20
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20.20.2
+          node-version: 22
           cache: 'npm'
       - name: Bootstrap project
         run: |
@@ -103,7 +102,7 @@ jobs:
       - name: Use Node.js 20
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20.20.2
+          node-version: 22
           cache: npm
       - name: Bootstrap project
         run: |
@@ -138,7 +137,7 @@ jobs:
       - name: Use Node.js 20
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20.20.2
+          node-version: 22
           cache: npm
       - name: Bootstrap project
         run: |

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "version": "5.0.31",
   "engines": {
-    "node": ">=16"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
BREAKING CHANGE: drop Node.js 20 support

### Description
Node.js 20 has reached EOL. https://nodejs.org/en/about/previous-releases


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
