### PR TITLE
chore: drop Node.js 20 support

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,13 +21,11 @@ jobs:
         node-version:
           - 16
           - 18
-          - 20
-          - 21
         include:
           - os: macos-latest
-            node-version: 20 # LTS
+            node-version: 22
           - os: windows-latest
-            node-version: 20 # LTS
+            node-version: 22
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -71,10 +69,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Use Node.js 20
+      - name: Use Node.js 22
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20.20.2
+          node-version: 22
           cache: 'npm'
       - name: Bootstrap project
         run: |
@@ -100,10 +98,10 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Use Node.js 20
+      - name: Use Node.js 22
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20.20.2
+          node-version: 22
           cache: npm
       - name: Bootstrap project
         run: |
@@ -135,10 +133,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Use Node.js 20
+      - name: Use Node.js 22
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20.20.2
+          node-version: 22
           cache: npm
       - name: Bootstrap project
         run: |


### PR DESCRIPTION
### Description
Node.js 20 has reached EOL. Dropping support in this module. 

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
